### PR TITLE
Add Dietary Restrictions to FoodItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,32 @@
 # Robinfood
 
+This application is mostly a backend for scraping data in a cron,
+and posting the choices on a cron.
+
+**It currently does not have a UI, so this is all managed via** `rails_console`.
+
 ## Development
 
 You'll need to set the following environment variables:
 
-- FOODA_USERNAME
-- FOODA_PASSWORD
+- `FOODA_USERNAME`
+- `FOODA_PASSWORD`
 
 To open up a rails console, you can:
 
 - Copy `docker-compose.override.yml.example` into `docker-compose.override.yml`.
 - `./run rails c`
+
+## Scraping
+
+In order to invoke the scraper, you'll need to run the `Scraper::Actions::Scrape`  action.
+
+The scrape action is done on a schedule (see: `config/schedule.yml`).
+
+```ruby
+require 'scraper/actions/scrape'
+
+Scraper::Actions::Scrape.new.execute
+```
+
+##

--- a/app/models/food_item.rb
+++ b/app/models/food_item.rb
@@ -15,19 +15,21 @@ class FoodItem < ApplicationRecord
   SIDE_DISHES = [SIDE, BEVERAGE, DESSERT]
 
   def self.from_element(element, date_offered)
-    restaurant = element.attribute('data-vendor_name').gsub(/\W+$/, '')
-    category   = element.attribute('data-category')
-    name       = element.at_css('.item__name').text.squish
-    price      = element.at_css('.item__price').text.gsub!('$', '').to_f
-    url        = element.at_css('a').attribute('href')
+    restaurant           = element.attribute('data-vendor_name').gsub(/\W+$/, '')
+    category             = element.attribute('data-category')
+    name                 = element.at_css('.item__name').text.squish
+    price                = element.at_css('.item__price').text.gsub!('$', '').to_f
+    url                  = element.at_css('a').attribute('href')
+    dietary_restrictions = (element.attribute('data-dietary_restriction') || '').split(',')
 
     new.tap do |instance|
-      instance.name         = name
-      instance.price        = price
-      instance.restaurant   = restaurant
-      instance.category     = category
-      instance.url          = url
-      instance.date_offered = date_offered
+      instance.name                 = name
+      instance.price                = price
+      instance.restaurant           = restaurant
+      instance.category             = category
+      instance.url                  = url
+      instance.date_offered         = date_offered
+      instance.dietary_restrictions = dietary_restrictions
     end
   end
 

--- a/db/migrate/20191014235529_add_dietary_restrictions_to_food_item.rb
+++ b/db/migrate/20191014235529_add_dietary_restrictions_to_food_item.rb
@@ -1,0 +1,5 @@
+class AddDietaryRestrictionsToFoodItem < ActiveRecord::Migration[6.0]
+  def change
+    add_column :food_items, :dietary_restrictions, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_10_001544) do
+ActiveRecord::Schema.define(version: 2019_10_14_235529) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2019_09_10_001544) do
     t.date "date_offered"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "dietary_restrictions", default: [], array: true
   end
 
 end


### PR DESCRIPTION
This commit adds a migration to support dietary_restrictions. If none is
present, it will default to an empty array.

This will be populated in future scrapes.