### PR TITLE
Properly move items out of available items

### DIFF
--- a/app/lib/recommendations/engines/v2.rb
+++ b/app/lib/recommendations/engines/v2.rb
@@ -47,7 +47,7 @@ module Recommendations
                 item = main_items.any? ? main_items.sample : side_items.sample
 
                 if item
-                  selected_items.delete_at(available_items.index(item))
+                  selected_items.delete_at(selected_items.index(item))
                   recommendations.push(item)
                   budget_remaining -= item.price
                 else


### PR DESCRIPTION
# Problem

Sometimes duplicate data was being displayed in the recommendations in the v2 engine.

# Proposal

Each time we make a recommendation, we should reduce the overall working data set. Before, we were only reducing the items available in each iteration and not from the overall working dataset